### PR TITLE
Allow for node versions greater than 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/lmaccherone/node-localstorage",
   "engines": {
-    "node": "0.8.x"
+    "node": ">=0.8"
   },
   "repository": {
     "type" : "git",


### PR DESCRIPTION
Currently only 0.8 is supported, but 0.10 works fine. This fixes that.
