### PR TITLE
Do not fail if the directory being created already exists

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -50,7 +50,7 @@ task('test', 'Run the CoffeeScript test suite with nodeunit', () ->
 )
 
 task('testES6', 'Run tests in testES6 folder with --harmony-proxies flag', () ->
-  runSync("node --harmony-proxies $(which nodeunit) testES6/*.coffee")
+  runSync("node --harmony-proxies node_modules/nodeunit/bin/nodeunit testES6/es6Test.coffee")
 )
 
 task('publish', 'Publish to npm and add git tags', () ->

--- a/LocalStorage.coffee
+++ b/LocalStorage.coffee
@@ -111,9 +111,15 @@ class LocalStorage extends events.EventEmitter
 
       @length = _keys.length
       return
-    catch
+    catch e
       # If it errors, that means it didn't exist, so create it
-      fs.mkdirSync(@_location)
+      if e.code != "ENOENT"
+        throw e
+      try
+        fs.mkdirSync(@_location)
+      catch e
+        if e.code != "EEXIST"
+          throw e
       return
     
   setItem: (key, value) ->


### PR DESCRIPTION
We're using the library from multiple processes and the initialization fails from time to time with the following exception:

```
[12:43:10] E/configParser - Error: EEXIST: file already exists, mkdir '/mnt/hsuia/automation/14284809/protractor/.localStorage'
    at Object.fs.mkdirSync (fs.js:905:18)
    at LocalStorage._init (/mnt/hsuia/automation/14284809/protractor/node_modules/node-localstorage/LocalStorage.js:151:12)
    at new LocalStorage (/mnt/hsuia/automation/14284809/protractor/node_modules/node-localstorage/LocalStorage.js:121:12)
    at /mnt/hsuia/automation/14284809/protractor/protractor/helpers/js-api/vsphere.js:2242:10
    at Object.<anonymous> (/mnt/hsuia/automation/14284809/protractor/protractor/helpers/js-api/vsphere.js:2399:3)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
```

It looks like the localStorage directory does not exist initially, but is created by another process in the meantime. I reproduced the error locally by halting with a debugger on the *fs.mkdirSync(@_location)* line and creating the folder manually before continuing.

I've verified the desired behavior and ran the tests successfully.