### PR TITLE
Add register.js to pollyfill node.js environment for testing browser targeted code

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ console.log(localStorage.getItem('myFirstKey'));
 Polyfil your node.js environment with this as the global localStorage when launching your own code
 
 ```sh
-node -r node-localstorage/register test.js
+node -r node-localstorage/register my-code.js
 ```
 
 ## Installation ##

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ localStorage.setItem('myFirstKey', 'myFirstValue');
 console.log(localStorage.getItem('myFirstKey'));
 ```
 
-### Node ###
+### Polyfill on Node.js ###
 
 Preload `localStorage` at node startup as
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ localStorage.setItem('myFirstKey', 'myFirstValue');
 console.log(localStorage.getItem('myFirstKey'));
 ```
 
+### Node ###
+
+Preload `localStorage` at node startup as
+
+```sh
+node -r node-localstorage/register test.js
+```
+
 ## Installation ##
 
 `npm install node-localstorage`

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ console.log(localStorage.getItem('myFirstKey'));
 
 ### Polyfill on Node.js ###
 
-Preload `localStorage` at node startup as
+Polyfil your node.js environment with this as the global localStorage when launching your own code
 
 ```sh
 node -r node-localstorage/register test.js

--- a/register.js
+++ b/register.js
@@ -1,0 +1,4 @@
+if (typeof localStorage === "undefined" || localStorage === null) {
+  var LocalStorage = require('node-localstorage').LocalStorage;
+  global.localStorage = new LocalStorage('./scratch');
+}


### PR DESCRIPTION
Fixes #42.

Based on the readme, tested via https://github.com/unihooks/unihooks/blob/master/test/register.js.
It makes possible to directly run node with enabled localstorage `node -r node-localstorage/register test.js`.