### PR TITLE
Implemented temp storage through fs-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-localstorage",
-  "version": "2.1.5",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -922,6 +922,11 @@
           "dev": true
         }
       }
+    },
+    "mock-fs": {
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.4.tgz",
+      "integrity": "sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "mock-fs": "^4.10.4",
     "write-file-atomic": "^1.1.4"
   }
 }

--- a/test/in-memory-test.coffee
+++ b/test/in-memory-test.coffee
@@ -37,24 +37,19 @@ tape('on fs', (test) =>
 )
 
 tape('in memory and on fs', (test) =>
-  localStorageFs = new LocalStorage(os.tmpdir())
+  localStorageFs = new LocalStorage('./scratch2')
   localStorageMem = new LocalStorage()
 
-  localStorageFs.setItem('item', 'fs')
-  localStorageMem.setItem('item', 'mem')
+  fileError = 'ENOENT: no such file or directory'
+
+  test.doesNotThrow((-> localStorageFs.setItem('item', 'fs')), fileError) # currenlty failing
+  test.doesNotThrow((-> localStorageMem.setItem('item', 'mem')), fileError)
   
-  test.notEqual(localStorageFs.getItem('item'), 'mem'); # currenlty failing
+  test.notEqual(localStorageFs.getItem('item'), 'mem');
   test.notEqual(localStorageMem.getItem('item'), 'fs');
   
-  
-  test.doesNotThrow(
-    -> localStorageFs._deleteLocation(), 
-    'Error: ENOENT: no such file or directory'
-  )
-  test.doesNotThrow(
-    -> localStorageMem._deleteLocation(), 
-    'Error: ENOENT: no such file or directory'
-  ) # currenlty failing
+  test.doesNotThrow((-> localStorageFs._deleteLocation()), fileError) # currenlty failing
+  test.doesNotThrow((-> localStorageMem._deleteLocation()), fileError)
 
   test.end()
 )

--- a/test/in-memory-test.coffee
+++ b/test/in-memory-test.coffee
@@ -1,0 +1,235 @@
+{LocalStorage} = require('../')
+path = require('path')
+os = require('os')
+fs = require('fs')
+mockFs = require('mock-fs');
+tape = require('tape')
+
+repeat = (string, count) ->
+  a = []
+  while count--
+    a.push(string)
+  return a.join('')
+
+
+tape('in memory', (test) =>
+  localStorage = new LocalStorage()
+  test.equal(localStorage._location, path.resolve(os.tmpdir()))
+  test.true(localStorage._memoryFs)
+  
+  localStorage.setItem('/', 'something')
+  filename = path.join(localStorage._location, encodeURIComponent('/'))
+  test.true(fs.existsSync(filename))
+  
+  localStorage._deleteLocation()
+  test.false(fs.existsSync(filename))
+  
+  test.end()
+)
+
+tape('on fs', (test) =>
+  localStorage = new LocalStorage('./scratch')
+  test.false(localStorage._memoryFs)
+  
+  localStorage._deleteLocation()
+  
+  test.end()
+)
+
+tape('in memory and on fs', (test) =>
+  localStorageFs = new LocalStorage(os.tmpdir())
+  localStorageMem = new LocalStorage()
+
+  localStorageFs.setItem('item', 'fs')
+  localStorageMem.setItem('item', 'mem')
+  
+  test.notEqual(localStorageFs.getItem('item'), 'mem'); # currenlty failing
+  test.notEqual(localStorageMem.getItem('item'), 'fs');
+  
+  
+  test.doesNotThrow(
+    -> localStorageFs._deleteLocation(), 
+    'Error: ENOENT: no such file or directory'
+  )
+  test.doesNotThrow(
+    -> localStorageMem._deleteLocation(), 
+    'Error: ENOENT: no such file or directory'
+  ) # currenlty failing
+
+  test.end()
+)
+
+tape('localStorage API', (test) =>
+  localStorage = new LocalStorage()
+  
+  localStorage.setItem('/', 'something')
+  test.equal(localStorage.getItem('/'), 'something')
+  o = {a:1, b:'some string', c:{x: 1, y: 2}}
+  localStorage.setItem('2', o)
+  test.deepEqual(localStorage.getItem('2'), o.toString())
+
+  a = [1, 'some string', {a:1, b:'some string', c:{x: 1, y: 2}}]
+  localStorage.setItem('2', a)
+  test.deepEqual(localStorage.getItem('2'), a.toString())
+  
+  test.deepEqual(localStorage._keys, ['/', '2'])
+  test.equal(localStorage.length, 2)
+
+  localStorage.removeItem('2')
+  test.equal(localStorage.getItem('2'), null)
+  
+  test.deepEqual(localStorage._keys, ['/'])
+  test.equal(localStorage.length, 1)
+  
+  test.equal(localStorage.key(0), '/')
+  localStorage.clear()
+  test.equal(localStorage.length, 0)
+  
+  localStorage._deleteLocation()
+
+  test.end()
+)
+
+tape('quota', (test) =>
+  n10 = '01234567890'
+  n100 = repeat('0123456789', 10)
+  n1000 = repeat(n100, 10)
+  n10000 = repeat(n1000, 10)
+
+  ls = new LocalStorage(null, 3000)
+  ls.setItem(1, n1000)
+  ls.setItem(2, n1000)
+  ls.setItem(3, n1000)
+  test.equal(ls._getBytesInUse(), 3000)
+
+  f = () ->
+    ls.setItem(6, n10)
+
+  test.throws(f, Error)
+  ls.setItem(2, n1000)  # Should not throw because it replaces one of equal size
+
+  ls.removeItem(3)
+  ls.setItem(7, n100)
+  f2 = () ->
+    ls.setitem(8, n1000)
+  test.throws(f2, Error)
+
+  ls._deleteLocation()
+  test.end()
+)
+
+tape('no new keyword', (test) =>
+  local = LocalStorage()
+  local.setItem('Hello', ' world!')
+  test.equals(local.getItem('Hello'), ' world!')
+  local._deleteLocation()
+  test.end()
+)
+
+tape('null', (test) =>
+  local = LocalStorage()
+  test.equals(local.getItem('junk'), null)
+  local._deleteLocation()
+  test.end()
+)
+
+tape('remove keys', (test) =>
+  localStorage = new LocalStorage();
+
+  localStorage.setItem('a', 'hello')
+  localStorage.setItem('b', 'hello')
+  localStorage.setItem('c', 'hello')
+  localStorage.setItem('d', 'hello')
+
+  test.deepEqual(localStorage._keys, ['a', 'b', 'c', 'd'])
+  localStorage.removeItem('c')
+  test.deepEqual(localStorage._keys, ['a', 'b', 'd'])
+  localStorage.removeItem('a');
+  test.deepEqual(localStorage._keys, ['b', 'd'])
+  localStorage.removeItem('b')
+  test.deepEqual(localStorage._keys, ['d'])
+  localStorage.removeItem('d')
+  test.deepEqual(localStorage._keys, [])
+
+  localStorage._deleteLocation()
+  test.end()
+)
+
+tape('events', (test) =>
+  localStorage = new LocalStorage()
+
+  expectedUrl = "pid:" + process.pid
+  key = null; oldVal = null; newVal = null; url = null
+  handleEvent = (evnt) ->
+    key = evnt.key
+    oldVal = evnt.oldValue
+    newVal = evnt.newValue
+    url = evnt.url
+
+  localStorage.on('storage', handleEvent)
+  
+  localStorage.setItem('a', 'something')
+  test.equal(localStorage.getItem('a'), 'something')
+  test.equal(key, 'a')
+  test.equal(oldVal, null)
+  test.equal(newVal, 'something')
+  test.equal(url, expectedUrl)
+
+  key = null; oldVal = null; newVal = null; url = null
+  localStorage.setItem('a', 'somethingnew')
+  test.equal(localStorage.getItem('a'), 'somethingnew')
+  test.equal(key, 'a')
+  test.equal(oldVal, 'something')
+  test.equal(newVal, 'somethingnew')
+  test.equal(url, expectedUrl)
+  
+  key = null; oldVal = null; newVal = null; url = null
+  localStorage.removeItem('a')
+  test.equal(localStorage.getItem('a'), null)
+  test.equal(key, 'a')
+  test.equal(oldVal, 'somethingnew')
+  test.equal(newVal, null)
+  test.equal(url, expectedUrl)
+
+  key = null; oldVal = null; newVal = null; url = null
+  localStorage.clear();
+  test.equal(localStorage.getItem('a'), null)
+  test.equal(key, null)
+  test.equal(oldVal, null)
+  test.equal(newVal, null)
+  test.equal(url, expectedUrl)
+  
+  localStorage._deleteLocation()
+  test.end()
+)
+
+tape('get stat', (test) =>
+  localStorage = new LocalStorage()
+
+  o = {a:1, b:'some string', c:{x: 1, y: 2}}
+  localStorage.setItem('stat', o)
+  test.deepEqual(localStorage.getItem('stat'), o.toString())
+
+  test.ok(localStorage._getStat('stat')?)
+  test.equal(localStorage._getStat('not there'), null)
+
+  localStorage._deleteLocation()
+  test.end()
+)
+
+tape('empty string', (test) =>
+  localStorage = new LocalStorage()
+
+  localStorage.setItem('', 'something')
+  test.equal(localStorage.getItem(''), 'something')
+
+  test.equal(localStorage.key(0), '')
+
+  localStorage._deleteLocation()
+  test.end()
+)
+
+tape('after all tests', (test) =>
+  mockFs.restore()
+  test.end()
+)


### PR DESCRIPTION
Trying to implement the feature as spoken about on #15 (non persistent storage)
Seems to work great except when many instances of LocalStorage are run simultaneously, see [this part](https://github.com/lmaccherone/node-localstorage/blob/d06cd893578a84747d9161ea7a821e8e6640ead5/test/in-memory-test.coffee#L39-L55) of the tests.

By the way, I wanted to illustrate the confusion between the two storage types, but I'm now realizing two things : 
* The same path (`os.tmpdir()`) is used for both of them, and there would also be a mess with two instances using the the same path on the actual file system. _edit_: same path case removed.
* Once a LocalStorage is instanciated without a path and mock-fs has taken over, the whole `fs` module would be affected. Also on other parts of the application.