### PR TITLE
Changed how keys and values are interpreted.

### DIFF
--- a/LocalStorage.coffee
+++ b/LocalStorage.coffee
@@ -19,7 +19,7 @@ _escapeKey = (key) ->
   if key is ''
     newKey = KEY_FOR_EMPTY_STRING
   else
-    newKey = key.toString()
+    newKey = "#{key}"
   return newKey
 
 class QUOTA_EXCEEDED_ERR extends Error
@@ -133,7 +133,7 @@ class LocalStorage extends events.EventEmitter
     key = _escapeKey(key)
     encodedKey = encodeURIComponent(key)
     filename = path.join(@_location, encodedKey)
-    valueString = value.toString()
+    valueString = "#{value}"
     valueStringLength = valueString.length
     metaKey = @_metaKeyMap[key]
     existsBeforeSet = !!metaKey

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ node -r node-localstorage/register my-code.js
 
 ## Changelog ##
 
+* 2.1.7 - 2020-06-08 - Fixed stringifying null and undefined (thanks @gamesaucer)
 * 2.1.6 - 2020-04-10 - Fix backward compatibility bug (thanks @WillBartee)
 * 2.1.5 - 2019-12-02 - Fixed empty string key(n) return (@appy-one, thanks for reporting)
 * 2.1.2 thru 2.1.4 - 2019-11-17 - Upgrading and testing npm publish scripts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-localstorage",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "main": "./LocalStorage",
   "description": "A drop-in substitute for the browser native localStorage API that runs on node.js.",
   "keywords": [

--- a/test/no-tostring-test.coffee
+++ b/test/no-tostring-test.coffee
@@ -1,0 +1,28 @@
+{LocalStorage} = require('../')
+tape = require('tape')
+
+tape('use key without toString', (test) =>
+  localStorage = new LocalStorage('./scratch11')
+
+  test.doesNotThrow(() => localStorage.setItem(null, 'foo'))
+  test.doesNotThrow(() => localStorage.setItem(undefined, 'bar'))
+
+  test.equal(localStorage.getItem('null'), 'foo')
+  test.equal(localStorage.getItem('undefined'), 'bar')
+
+  localStorage._deleteLocation()
+  test.end()
+)
+
+tape('set value without toString', (test) =>
+  localStorage = new LocalStorage('./scratch12')
+
+  test.doesNotThrow(() => localStorage.setItem('foo', null))
+  test.doesNotThrow(() => localStorage.setItem('bar', undefined))
+
+  test.equal(localStorage.getItem('foo'), 'null')
+  test.equal(localStorage.getItem('bar'), 'undefined')
+
+  localStorage._deleteLocation()
+  test.end()
+)


### PR DESCRIPTION
Using `x.toString()` prevents values like `null` and `undefined` from being used as keys or values, which is inconsistent with `window.localStorage` in the browser. Using `"#{x}"` instead allows the use of values that do not have `.toString()` methods, which is consistent with how the Web Storage API functions.

I thought about making an issue for this first, but since it's such a simple change, I figured I might as well just put in a pull request.

The code below can verify that values like `null` and `undefined` are indeed turned into strings in the browser (e.g. `null` is equivalent to `"null"`):

```JavaScript
const fn = v => {
  const r = String(Math.random())
  localStorage.setItem(v,r)
  return localStorage.getItem(`${v}`) === r
}
fn(null) && fn(undefined)
```