### PR TITLE
fix the `options` argument to `writeFileSync`

### DIFF
--- a/LocalStorage.coffee
+++ b/LocalStorage.coffee
@@ -143,7 +143,7 @@ class LocalStorage extends events.EventEmitter
       oldLength = 0
     if @_bytesInUse - oldLength + valueStringLength > @quota
       throw new QUOTA_EXCEEDED_ERR()
-    writeSync(filename, valueString, 'utf8')
+    writeSync(filename, valueString, {encoding:'utf8'})
     unless existsBeforeSet
       metaKey = new MetaKey(encodedKey, (@_keys.push(key)) - 1)
       metaKey.size = valueStringLength


### PR DESCRIPTION
I noticed that you were sending 'utf8' as the `options` argument to the write-file-atomic `sync` method. I saw that that method expects an object instead of a string, and I set some breakpoints to verify that there's no point where it does something like check if it's a string and does something different, and it turns out, nope, if you send it a string it just ignores it.

Note: 'utf8' is the default encoding even if you didn't supply that argument.